### PR TITLE
fixes #5

### DIFF
--- a/demo/basic_demo.cpp
+++ b/demo/basic_demo.cpp
@@ -10,8 +10,6 @@
 // (thread-safe) and 'lite' (single-threaded) versions of signals.
 // Therefore, vdk::lite::signal can be used instead of vdk::signal.
 
-using vdk::signal;
-
 namespace
 {
 void function(int arg)
@@ -52,7 +50,7 @@ public:
 void signals_basic_demo()
 {
     // Create a signal with no connected slots
-    signal<void(int)> sig;
+    vdk::signal<void(int)> sig;
 
     // Connect the signal to a function
     sig.connect(function);

--- a/demo/cross_thread_calls.cpp
+++ b/demo/cross_thread_calls.cpp
@@ -10,7 +10,6 @@
 #include "demo.h"
 
 using std::string;
-using vdk::signal;
 using vdk::context;
 using vdk::exec;
 using vdk::signals_execute;
@@ -65,7 +64,7 @@ void signals_cross_thread_calls()
     // In order to receive cross-thread signal emissions that thread
     // must call signals_execute() in a loop.
 
-    signal<void(int, int)> sig;
+    vdk::signal<void(int, int)> sig;
 
     // Flag is used here for simple start synchronization
     std::atomic_bool flag = false;

--- a/demo/track_objects.cpp
+++ b/demo/track_objects.cpp
@@ -12,7 +12,6 @@
 // vdk::lite::context instead of vdk::context.
 
 using std::string;
-using vdk::signal;
 using vdk::context;
 
 namespace
@@ -63,7 +62,7 @@ public:
 
 void signals_track_objects()
 {
-    signal<void(const string &)> sig;
+    vdk::signal<void(const string &)> sig;
 
     {
         // This object provides a context for slot invocations, so it


### PR DESCRIPTION
basic_demo.cpp:13:12: error: 'template<class> class vdk::signal' conflicts with a previous declaration #5

https://github.com/vdksoft/signals/issues/5